### PR TITLE
removed unneeded warning-surpressing line

### DIFF
--- a/src/Commands/HelpCommand.hpp
+++ b/src/Commands/HelpCommand.hpp
@@ -17,8 +17,6 @@ public:
 
 	virtual void Execute(Client* sender, const CommandArgs& args)
 	{
-		(void)args; // Quiet compiler
-
 		Server* server = Server::GetInstance();
 		uint8_t userType = sender->GetUserType();
 


### PR DESCRIPTION
In the past this line was used to suppress the compiler's warning about parameter args being not used. This is not necessary anymore.